### PR TITLE
Better Premailer server error handling

### DIFF
--- a/premailer.js
+++ b/premailer.js
@@ -101,8 +101,10 @@ exports.prepare = function(_options, next) {
 		try {
 			apiResponse = JSON.parse(body);
 		} catch(ex) {
-			next(ex);
-			return;
+			if (body.match(/Application Error/gi)) {
+				return next('Premailer returned an unkown server error');
+			}
+			return next(ex);
 		}
 		if (options.fetchHTML) {
 			getHTML();


### PR DESCRIPTION
I've found that lately the Premailer server has been failing inconsistently, and the error message I was getting back from premailer-api was `SyntaxError: Unexpected token <` along with a stack trace. This was causing me to think I was passing invalid HTML as input. After debugging, I found out that in fact, this error is due to premailer-api's current error handling assuming the Premailer response is valid JSON.  In fact, (unfortunately) the response I'm getting from Premailer looks like this currently:

```
<!DOCTYPE html>
<html>
<head>
  <meta name="viewport" content="width=device-width, initial-scale=1">
  <style type="text/css">
    html, body, iframe { margin: 0; padding: 0; height: 100%; }
    iframe { display: block; width: 100%; border: none; }
  </style>
<title>Application Error</title>
</head>
<body>
  <iframe src="//s3.amazonaws.com/heroku_pages/error.html">
    <p>Application Error</p>
  </iframe>
</body>
</html>
```

That is the `body` value being passed to `JSON.parse`, hence the unexpected token error. Obviously the error coming back from Premailer itself appears to be due to bad handling on their side, but I guess trying to deal with it in a sensible way is at least better than raising it as a misleading error from premailer-api.

The suggested patch is ugly, but at least allows for clean reporting of what's going on to the end user of the lib.  Now, how to go about fixing the Premailer server....
